### PR TITLE
[GLM] Add external regressor

### DIFF
--- a/bst_plugin/MANIFEST.wip
+++ b/bst_plugin/MANIFEST.wip
@@ -1,3 +1,5 @@
 process_nst_compute_glm.m
 process_nst_compute_ttest.m
 process_nst_compute_group_ttest.m
+nst_ols_fit.m
+nst_ar_irls_fit.m

--- a/bst_plugin/nst_ar_irls_fit.m
+++ b/bst_plugin/nst_ar_irls_fit.m
@@ -1,0 +1,11 @@
+function [B,covB,dfe]=nst_ar_irls_fit(y,X,pmax)
+	stat=nirs.math.ar_irls(y,X, pmax );
+    
+    B=stat.beta;
+    
+    covB=zeros( size(stat.covb,1), size(stat.covb,2),size(stat.covb,3));
+    for i=1:size(stat.covb,3)
+       covB(:,:,i)= stat.covb(:,:,i,i);
+    end    
+    dfe=stat.dfe;
+end

--- a/bst_plugin/nst_ols_fit.m
+++ b/bst_plugin/nst_ols_fit.m
@@ -1,0 +1,12 @@
+function [B,covB,dfe]=nst_ols_fit(y,X)
+    B= pinv(X'*X)* X'*y; % or B=X\y; 
+    
+    residual=y - X*B ;     
+    covE=cov(residual);
+    
+    for i=1:size(residual,2)     
+        covB(:,:,i)=covE(i,i) * pinv(transpose(X)*X);
+    end
+    dfe = size(y,1) - rank(X);
+    
+end

--- a/bst_plugin/process_nst_compute_glm.m
+++ b/bst_plugin/process_nst_compute_glm.m
@@ -82,7 +82,7 @@ function sProcess = GetDescription() %#ok<DEFNU>
     
     sProcess.options.fitting.Comment = 'Fitting method';
     sProcess.options.fitting.Type    = 'combobox';
-    sProcess.options.fitting.Value   = {1, {'OLS','AR-IRLS(AnalizIR toolbox)' }};
+    sProcess.options.fitting.Value   = {1, {'OLS','AR-IRLS(AnalyzIR toolbox)' }};
 
 end
 
@@ -192,11 +192,11 @@ function OutputFiles = Run(sProcess, sInput)
         Out_DataMat.Description = names'; % Names of the regressors 
         Out_DataMat.ChannelFlag =  ones(n_regressor,1);   % List of good/bad channels (1=good, -1=bad)
         Out_DataMat.Time        =  DataMat.Time;
+        Out_DataMat.DisplayUnits = DataMat.DisplayUnits; 
         Out_DataMat = bst_history('add', Out_DataMat, 'Design', FormatComment(sProcess));
+        
         OutputFiles{end+1} = bst_process('GetNewFilename', fileparts(sInput.FileName), 'design_matrix');
-        % Save on disk
-        save(OutputFiles{end}, '-struct', 'Out_DataMat');
-        % Register in database
+        bst_save(OutputFiles{end}, Out_DataMat, 'v6');
         db_add_data(iStudy, OutputFiles{end}, Out_DataMat);
     end 
     
@@ -235,13 +235,13 @@ function OutputFiles = Run(sProcess, sInput)
     Out_DataMat.Comment     = ['GLM_beta_matrix_' method_name];
     Out_DataMat.Description = names; % Names of the regressors 
     Out_DataMat.ChannelFlag =  ones(size(B,2),1);   % List of good/bad channels (1=good, -1=bad)
-    
     Out_DataMat = bst_history('add', Out_DataMat, DataMat.History, '');
     Out_DataMat = bst_history('add', Out_DataMat, 'GLM', FormatComment(sProcess));
 
     OutputFiles{end+1} = bst_process('GetNewFilename', fileparts(sInput.FileName), 'B_matrix');
-    save(OutputFiles{end}, '-struct', 'Out_DataMat');
+    bst_save(OutputFiles{end}, Out_DataMat, 'v6');
     db_add_data(iStudy, OutputFiles{end}, Out_DataMat);
+    
     
     % Saving B as maps
     for i_reg_name=1:length(names)
@@ -254,14 +254,11 @@ function OutputFiles = Run(sProcess, sInput)
         sDataOut.Time         = [1];
         sDataOut.DataType     = 'recordings';
         sDataOut.nAvg         = 1;
-        sDataOut.DisplayUnits = 'mmol.l-1'; %TODO: check scaling
+        sDataOut.DisplayUnits = 'U.A.'; %TODO: check scaling
         
-        sStudy = bst_get('Study', sInput.iStudy);
-        OutputFiles{end+1} = bst_process('GetNewFilename', bst_fileparts(sStudy.FileName), ['data_beta_' names{i_reg_name}]);
-        sDataOut.FileName = file_short(OutputFiles{end});
-        bst_save(OutputFiles{end}, sDataOut, 'v7');
-        % Register in database
-        db_add_data(sInput.iStudy, OutputFiles{end}, sDataOut);
+        OutputFiles{end+1} = bst_process('GetNewFilename', fileparts(sInput.FileName), ['data_beta_' names{i_reg_name}]);
+        bst_save(OutputFiles{end}, sDataOut, 'v6');
+        db_add_data(iStudy, OutputFiles{end}, sDataOut);
     end
     
     % Saving the covB Matrix.
@@ -270,9 +267,12 @@ function OutputFiles = Run(sProcess, sInput)
     Out_DataMat.Comment     = [ 'GLM_covB_' method_name '_df=' int2str(dfe) ];
     Out_DataMat = bst_history('add', Out_DataMat, DataMat.History, '');
     Out_DataMat = bst_history('add', Out_DataMat, 'GLM', FormatComment(sProcess));
+    
     OutputFiles{end+1} = bst_process('GetNewFilename', fileparts(sInput.FileName), 'covB_matrix');
-    save(OutputFiles{end}, '-struct', 'Out_DataMat');
-    db_add_data(iStudy, OutputFiles{end}, Out_DataMat);    
+    bst_save(OutputFiles{end}, Out_DataMat, 'v6');
+    db_add_data(iStudy, OutputFiles{end}, Out_DataMat);
+        
+   
     
     % Saving the residual matrix.
     Out_DataMat = db_template('data');
@@ -287,10 +287,12 @@ function OutputFiles = Run(sProcess, sInput)
     
     Out_DataMat = bst_history('add', Out_DataMat, DataMat.History, '');
     Out_DataMat = bst_history('add', Out_DataMat, 'GLM', FormatComment(sProcess));
+    
     OutputFiles{end+1} = bst_process('GetNewFilename', fileparts(sInput.FileName), 'data_residual');
-    Out_DataMat.FileName = file_short(OutputFiles{end});
-    bst_save(OutputFiles{end}, Out_DataMat, 'v7');
+    bst_save(OutputFiles{end}, Out_DataMat, 'v6');
     db_add_data(iStudy, OutputFiles{end}, Out_DataMat);
+    
+
 end
 
 

--- a/bst_plugin/process_nst_compute_glm.m
+++ b/bst_plugin/process_nst_compute_glm.m
@@ -156,7 +156,7 @@ function OutputFiles = Run(sProcess, sInput)
                              'doesn''t match design matrix dimension']);
                 return;
             end
-            if ~(size(C,2) == size(name,1))
+            if ~(size(C,2) == length(name))
                 bst_error([external_function_names ' have to return one name for each regressor']);    
                 return;
             end

--- a/bst_plugin/process_nst_compute_glm.m
+++ b/bst_plugin/process_nst_compute_glm.m
@@ -145,29 +145,29 @@ function OutputFiles = Run(sProcess, sInput)
         X=[X C];
         names=[names name];
     end
-    
-    if ~strcmp(sProcess.options.external.Value,'')
-        external_function_names = sProcess.options.external.Value;
-       try
-           [C,name]=feval( str2func(external_function_names),sProcess, sInput);
+    if exist(sProcess.options.external.Value)
+        if ~strcmp(sProcess.options.external.Value,'')
+            external_function_names = sProcess.options.external.Value;
+           try
+               [C,name]=feval( str2func(external_function_names),sProcess, sInput);
 
-            if ~(size(C,1) == size(X,1))
-                bst_error([ 'Dimension of the external regressor returned by ' external_function_names ...
-                             'doesn''t match design matrix dimension']);
-                return;
-            end
-            if ~(size(C,2) == length(name))
-                bst_error([external_function_names ' have to return one name for each regressor']);    
-                return;
-            end
-            X=[X C];
-            names=[names name];   
-       catch
-           bst_error([ 'Error during the call of ' external_function_names ]);  
+                if ~(size(C,1) == size(X,1))
+                    bst_error([ 'Dimension of the external regressor returned by ' external_function_names ...
+                                 'doesn''t match design matrix dimension']);
+                    return;
+                end
+                if ~(size(C,2) == length(name))
+                    bst_error([external_function_names ' have to return one name for each regressor']);    
+                    return;
+                end
+                X=[X C];
+                names=[names name];   
+           catch
+               bst_error([ 'Error during the call of ' external_function_names ]);  
 
-       end             
-    end   
-    
+           end             
+        end   
+    end
     
     % Check the rank of the matrix
     n_regressor=size(X,2);


### PR DESCRIPTION
Hi. 

This PR add a ( temporary, I think ) solution to add external regressor to the design matrix. 

It ask the user to enter the name of a function he coded, and call it with the following argument : sProcess and sInput. 

For example, using ' nst_add_external_regressor ' as input with the following function will add a constant regressor to the design matrix : 

```
function [C,name]=nst_add_external_regressor(sProcess, sInput)

    DataMat = in_bst_data(sInput.FileName);
    time=DataMat.Time - DataMat.Time(1);
    
    C=ones( size(time,2),1 );
    name='Constant';
```
when can also do this : @(sProcess,sInputs) nst_add_external_regressor(sProcess,sInputs,2) 
```
function [C,name]=nst_add_external_regressor(sProcess, sInput,order)

    DataMat = in_bst_data(sInput.FileName);
    time=DataMat.Time - DataMat.Time(1);
    
     name{order+1}='';
          
     C=legendre(time,order);
     for i=0:order
        name{i+1}= ['Legendre ' num2str(i) ];  
     end    
end

```
to insert the 3 first Legendre polynomials to the design matrix.  ( constant, x, ( 3x² -1)/3 ) 
    

This PR also expose ols and ar-irls method so that we can use them to compute the group-level analysis. 