### PR TITLE
 Events structure: Removed "samples", added "channels" and "notes" #199 

### DIFF
--- a/bst_plugin/bst_process.m
+++ b/bst_plugin/bst_process.m
@@ -739,7 +739,7 @@ function OutputFile = ProcessFilter(sProcess, sInput)
                 if isReadAll
                     sInput.A = FullFileMat(iRow, iCol);
                 else
-                    SamplesBounds = sFileIn.prop.samples(1) + iCol([1,end]) - 1;
+                    SamplesBounds = round(sFileIn.prop.times(1) .* sFileIn.prop.sfreq) + iCol([1,end]) - 1; 
                     sInput.A = in_fread(sFileIn, ChannelMat, iEpoch, SamplesBounds, iRow, ImportOptions);
                 end
                 sInput.Std = [];
@@ -844,7 +844,6 @@ function OutputFile = ProcessFilter(sProcess, sInput)
                         % Update file properties
                         sFileTemplate.prop.sfreq   = 1 / (sInput.TimeVector(2) - sInput.TimeVector(1));
                         sFileTemplate.prop.times   = [OutTime(1), OutTime(end)];
-                        sFileTemplate.prop.samples = round(sFileTemplate.prop.times .* sFileTemplate.prop.sfreq);
                         % Update events
                         sFileTemplate.events = panel_record('ChangeTimeVector', sFileTemplate.events, OldFreq, sInput.TimeVector);
                     end
@@ -908,7 +907,7 @@ function OutputFile = ProcessFilter(sProcess, sInput)
                     end
                 else
                     % Indices to write
-                    SamplesBounds = sFileOut.prop.samples(1) + iOutTime([1,end]) - 1;
+                    SamplesBounds = round(sFileOut.prop.times(1) .* sFileOut.prop.sfreq) + iOutTime([1,end]) - 1;
                     % Write block
                     sFileOut = out_fwrite(sFileOut, ChannelMatOut, iEpoch, SamplesBounds, iRow, sInput.A);
                 end

--- a/bst_plugin/nst_make_event_regressors.m
+++ b/bst_plugin/nst_make_event_regressors.m
@@ -1,13 +1,15 @@
-function events_mat = nst_make_event_regressors(events, filter, nb_samples)
+function events_mat = nst_make_event_regressors(events, filter, time)
 % NST_MAKE_EVENT_REGRESSORS build event design matrix from given events and filter
 % 
-%   EVENTS_MAT = NST_MAKE_EVENT_REGRESSORS(EVENTS, FILTER, NB_SAMPLES)
+%   EVENTS_MAT = NST_MAKE_EVENT_REGRESSORS(EVENTS, FILTER, TIME
 %
 %      EVENTS (struct array): 
 %          events as brainstorm structure (see DB_TEMPLATE('event'))
 %      FILTER (1D array of double): column vector 
 %          filter for convolution
-%      NB_SAMPLES (int): total number of samples (signal duration)
+%      TIME (array of float): reference time axis
+%
+%      Output:
 %
 %      EVENTS_MAT (matrix of double): 
 %          Event-induced design matrix built by convolving the events with
@@ -18,7 +20,7 @@ function events_mat = nst_make_event_regressors(events, filter, nb_samples)
 
 assert(size(filter, 2) == 1); % column vector
 
-events_tpz = nst_make_event_toeplitz_mtx(events, nb_samples, size(filter, 1));
+events_tpz = nst_make_event_toeplitz_mtx(events, time, size(filter, 1));
 regressors = cellfun(@(m) m*filter, events_tpz, 'UniformOutput', false);
 events_mat = horzcat(regressors{:});
 end

--- a/bst_plugin/nst_make_event_toeplitz_mtx.m
+++ b/bst_plugin/nst_make_event_toeplitz_mtx.m
@@ -1,4 +1,4 @@
-function events_tpz = nst_make_event_toeplitz_mtx(events, nb_samples, nb_coeffs)
+function events_tpz = nst_make_event_toeplitz_mtx(events, time_ref, nb_coeffs)
 % NST_MAKE_EVENT_TOEPLITZ_MTX build binary toeplitz matrices from given events, 
 % ready for convolution.
 % 
@@ -6,7 +6,7 @@ function events_tpz = nst_make_event_toeplitz_mtx(events, nb_samples, nb_coeffs)
 %
 %      EVENTS (struct array): 
 %          events as brainstorm structure (see DB_TEMPLATE('event'))
-%      NB_SAMPLES (int): total number of samples
+%      TIME_REF (array of float): reference temporal axis.
 %      NB_COEFFS (int): number of filter coefficients
 %
 %      EVENTS_TPZ (cell array of matrix of double): 
@@ -17,15 +17,15 @@ function events_tpz = nst_make_event_toeplitz_mtx(events, nb_samples, nb_coeffs)
 
     assert(isscalar(nb_coeffs));
     assert(round(nb_coeffs) == nb_coeffs);
-    assert(isscalar(nb_samples));
-    assert(round(nb_samples) == nb_samples);
-
+    assert(isnumeric(time_ref));
+    nb_samples = length(time_ref);
+   
     events_tpz = cell(1, length(events));
     for icondition=1:length(events)
         binary_seq = zeros(nb_samples, 1);
-        for ievent=1:size(events(icondition).samples, 2)
-            samples = events(icondition).samples(:, ievent);
-            binary_seq(samples(1):samples(2)) = 1;
+        for ievent=1:size(events(icondition).times, 2)
+            i_smpl = time_to_sample_idx(events(icondition).times(:, ievent), time_ref);
+            binary_seq(i_smpl(1):i_smpl(2)) = 1;
         end    
         events_tpz{icondition} = toeplitz(binary_seq, [binary_seq(1) zeros(1, nb_coeffs-1)]);
         if size(events_tpz{icondition}, 1) > nb_samples
@@ -34,4 +34,12 @@ function events_tpz = nst_make_event_toeplitz_mtx(events, nb_samples, nb_coeffs)
             events_tpz{icondition} = events_tpz{icondition}(1:nb_samples, :);
         end
     end
+end
+
+function samples = time_to_sample_idx(time, ref_time)
+if nargin < 2
+    assert(all(diff(diff(time))==0));
+    ref_time = time;
+end
+samples = round((time - ref_time(1)) / diff(ref_time(1:2))) + 1;
 end

--- a/bst_plugin/process_nst_glm_fit.m
+++ b/bst_plugin/process_nst_glm_fit.m
@@ -185,7 +185,7 @@ function OutputFiles = Run(sProcess, sInput) %#ok<DEFNU>
     % TODO: also handle single events for event-related design
     isExtended = false(1,length(ievents));
     for ievt=1:length(ievents)
-        isExtended(ievt) = (size(DataMat.Events(ievents(ievt)).samples, 1) == 2);
+        isExtended(ievt) = (size(DataMat.Events(ievents(ievt)).times, 1) == 2);
     end
     if ~all(isExtended)
          bst_error(sprintf('Simple events not supported: %s ', ...

--- a/bst_plugin/process_nst_glm_fit.m
+++ b/bst_plugin/process_nst_glm_fit.m
@@ -508,8 +508,7 @@ function [X, names, hrf] = make_design_matrix(time, events, hrf_type, hrf_durati
     end
     
     %% Make stimulus-induced design matrix
-    n_samples = length(time);
-    X = nst_make_event_regressors(events, hrf, n_samples);
+    X = nst_make_event_regressors(events, hrf, time);
     names = {events.label};
     
     %% Add trend function

--- a/bst_plugin/process_nst_import_csv_events.m
+++ b/bst_plugin/process_nst_import_csv_events.m
@@ -364,10 +364,8 @@ for iNew = 1:length(newEvents)
     end
     % Make sure that the sample indices are round values
     if ~isempty(newEvents(iNew).samples)
-        newEvents(iNew).samples = round(newEvents(iNew).samples);
         newEvents(iNew).times   = newEvents(iNew).samples ./ sFile.prop.sfreq;
     else
-        newEvents(iNew).samples = round(newEvents(iNew).times .* sFile.prop.sfreq);
         newEvents(iNew).times   = newEvents(iNew).samples ./ sFile.prop.sfreq;
     end
     % If event does not exist yet: add it at the end of the list
@@ -385,13 +383,11 @@ for iNew = 1:length(newEvents)
         %TODO, tell FT that if events are extended and were previously
         % single then bug -> FIX IT
         sFile.events(iEvt).times      = [sFile.events(iEvt).times, newEvents(iNew).times];
-        sFile.events(iEvt).samples    = [sFile.events(iEvt).samples, newEvents(iNew).samples];
         sFile.events(iEvt).epochs     = [sFile.events(iEvt).epochs, newEvents(iNew).epochs];
         sFile.events(iEvt).reactTimes = [sFile.events(iEvt).reactTimes, newEvents(iNew).reactTimes];
         % Sort by sample indices
         if (size(sFile.events(iEvt).samples, 2) > 1)
             [tmp__, iSort] = unique(sFile.events(iEvt).samples(1,:));
-            sFile.events(iEvt).samples = sFile.events(iEvt).samples(:,iSort);
             sFile.events(iEvt).times   = sFile.events(iEvt).times(:,iSort);
             sFile.events(iEvt).epochs  = sFile.events(iEvt).epochs(iSort);
             if ~isempty(sFile.events(iEvt).reactTimes)

--- a/bst_plugin/process_nst_import_csv_events.m
+++ b/bst_plugin/process_nst_import_csv_events.m
@@ -363,11 +363,11 @@ for iNew = 1:length(newEvents)
         iEvt = [];
     end
     % Make sure that the sample indices are round values
-    if ~isempty(newEvents(iNew).samples)
-        newEvents(iNew).times   = newEvents(iNew).samples ./ sFile.prop.sfreq;
-    else
-        newEvents(iNew).times   = newEvents(iNew).samples ./ sFile.prop.sfreq;
-    end
+    %if ~isempty(newEvents(iNew).samples)
+    %    newEvents(iNew).times   = newEvents(iNew).samples ./ sFile.prop.sfreq;
+    %else
+    %    newEvents(iNew).times   = newEvents(iNew).samples ./ sFile.prop.sfreq;
+    %end
     % If event does not exist yet: add it at the end of the list
     if isempty(iEvt)
         if isempty(sFile.events)

--- a/bst_plugin/process_nst_import_csv_events.m
+++ b/bst_plugin/process_nst_import_csv_events.m
@@ -308,10 +308,12 @@ function OutputFiles = Run(sProcess, sInputs) %#ok<DEFNU>
         cond_selection = strcmp(event_names, condition_names{icond});
         newEvents(icond).label = condition_names{icond};
         newEvents(icond).times = event_onsets(cond_selection);
-        newEvents(icond).epochs = ones(1, length(newEvents(icond).times));
+        newEvents(icond).epochs = ones(1, size(newEvents(icond).times, 2));
         if sProcess.options.span_type.Value ~= trial_span_types.START_ONLY
             newEvents(icond).times(2,:) = end_events(cond_selection);
         end
+        newEvents(icond).channels   = cell(1, size(newEvents(icond).times, 2));
+        newEvents(icond).notes      = cell(1, size(newEvents(icond).times, 2));
     end
         
     if sProcess.options.confirm_importation.Value
@@ -363,11 +365,7 @@ for iNew = 1:length(newEvents)
         iEvt = [];
     end
     % Make sure that the sample indices are round values
-    %if ~isempty(newEvents(iNew).samples)
-    %    newEvents(iNew).times   = newEvents(iNew).samples ./ sFile.prop.sfreq;
-    %else
-    %    newEvents(iNew).times   = newEvents(iNew).samples ./ sFile.prop.sfreq;
-    %end
+    newEvents(iNew).times = round(newEvents(iNew).times * sFile.prop.sfreq) ./ sFile.prop.sfreq;
     % If event does not exist yet: add it at the end of the list
     if isempty(iEvt)
         if isempty(sFile.events)
@@ -385,14 +383,18 @@ for iNew = 1:length(newEvents)
         sFile.events(iEvt).times      = [sFile.events(iEvt).times, newEvents(iNew).times];
         sFile.events(iEvt).epochs     = [sFile.events(iEvt).epochs, newEvents(iNew).epochs];
         sFile.events(iEvt).reactTimes = [sFile.events(iEvt).reactTimes, newEvents(iNew).reactTimes];
-        % Sort by sample indices
-        if (size(sFile.events(iEvt).samples, 2) > 1)
-            [tmp__, iSort] = unique(sFile.events(iEvt).samples(1,:));
+        sFile.events(iEvt).channels   = [sFile.events(iEvt).channels, newEvents(iNew).channels];
+        sFile.events(iEvt).notes      = [sFile.events(iEvt).notes, newEvents(iNew).notes];
+        % Sort by time
+        if (size(sFile.events(iEvt).times, 2) > 1)
+            [tmp__, iSort] = unique(bst_round(sFile.events(iEvt).times(1,:), 9));
             sFile.events(iEvt).times   = sFile.events(iEvt).times(:,iSort);
             sFile.events(iEvt).epochs  = sFile.events(iEvt).epochs(iSort);
             if ~isempty(sFile.events(iEvt).reactTimes)
                 sFile.events(iEvt).reactTimes = sFile.events(iEvt).reactTimes(iSort);
             end
+            sFile.events(iEvt).channels = sFile.events(iEvt).channels(iSort);
+            sFile.events(iEvt).notes = sFile.events(iEvt).notes(iSort);
         end
     end
     % Add color if does not exist yet

--- a/scripts/nst_tutorial_tapping.m
+++ b/scripts/nst_tutorial_tapping.m
@@ -73,6 +73,8 @@ movement_events.label = movement_label;
 movement_events.times = [577.3 662.2 689.3; ...
                          580.4 663.6 691.6];
 movement_events.epochs = ones(1, size(movement_events.times, 2));
+movement_events.channels   = cell(1, size(movement_events.times, 2));
+movement_events.notes      = cell(1, size(movement_events.times, 2));
 
 process_nst_import_csv_events('import_events', [], sFilesRun1, movement_events);
 

--- a/test/CSVImportTest.m
+++ b/test/CSVImportTest.m
@@ -54,7 +54,7 @@ classdef CSVImportTest < matlab.unittest.TestCase
             assert(~isempty(sFiles_processed));
             events = get_events(sFiles_processed);
             assert(length(events) == 1);
-            assert(size(events(1).samples, 1) == 2);
+            assert(size(events(1).times, 1) == 2);
             
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(1, 1) - 1482333540.553) <= nirs_dt);
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(2, 1) - 1482333570.823) <= nirs_dt);
@@ -78,7 +78,7 @@ classdef CSVImportTest < matlab.unittest.TestCase
                 'confirm_importation', 0);
             assert(~isempty(sFiles_processed));
             events = get_events(sFiles_processed);
-            assert(size(events(1).samples, 1) == 2);
+            assert(size(events(1).times, 1) == 2);
             all_onsets = [events.times];
             assert(all(all(all_onsets > 1482333369.446 - nirs_dt)));
             assert(all(all(all_onsets < 1482334222.724 + nirs_dt)));
@@ -238,7 +238,7 @@ classdef CSVImportTest < matlab.unittest.TestCase
                 'confirm_importation', 0);
             assert(~isempty(sFiles_processed));
             events = get_events(sFiles_processed);
-            assert(size(events(1).samples, 1) == 2);
+            assert(size(events(1).times, 1) == 2);
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(1, 1) - (1482333540.553 + offset)) < nirs_dt);
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(2, 1) - (1482333570.823 + offset)) < nirs_dt);
             utest_reset_bst();
@@ -261,7 +261,7 @@ classdef CSVImportTest < matlab.unittest.TestCase
                 'confirm_importation', 0);
             assert(~isempty(sFiles_processed));
             events = get_events(sFiles_processed);
-            assert(size(events(1).samples, 1) == 2);
+            assert(size(events(1).times, 1) == 2);
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(1, 1) - (1482333540.553 - 1482333369.446 + 50)) < nirs_dt);
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(2, 1) - (1482333570.823 - 1482333369.446 + 50)) < nirs_dt);
             utest_reset_bst();
@@ -297,7 +297,7 @@ classdef CSVImportTest < matlab.unittest.TestCase
                 'confirm_importation', 0);
             assert(~isempty(sFiles_processed));
             events = get_events(sFiles_processed);
-            assert(size(events(1).samples, 1) == 2);
+            assert(size(events(1).times, 1) == 2);
             assert(abs(events(strcmp({events.label}, 'clicGaudio')).times(1, 1) - 23.7) < nirs_dt);
             assert(abs(events(strcmp({events.label}, 'clicGaudio')).times(2, 1) - 25.7) < nirs_dt);
             utest_reset_bst();
@@ -360,7 +360,7 @@ classdef CSVImportTest < matlab.unittest.TestCase
                 'confirm_importation', 0);
             assert(~isempty(sFiles_processed));
             events = get_events(sFiles_processed);
-            assert(size(events(1).samples, 1) == 1);
+            assert(size(events(1).times, 1) == 1);
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(1) - 1482333540.553) < nirs_dt);
             utest_reset_bst();
             
@@ -382,7 +382,7 @@ classdef CSVImportTest < matlab.unittest.TestCase
                 'confirm_importation', 0);
             assert(~isempty(sFiles_processed));
             events = get_events(sFiles_processed);
-            assert(size(events(1).samples, 1) == 2);
+            assert(size(events(1).times, 1) == 2);
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(1, 1) - 1482333540.553) < nirs_dt);
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(2, 1) - 1482333570.823) < nirs_dt);
             utest_reset_bst();
@@ -418,7 +418,7 @@ classdef CSVImportTest < matlab.unittest.TestCase
                 'confirm_importation', 0);
             assert(~isempty(sFiles_processed));
             events = get_events(sFiles_processed);
-            assert(size(events(1).samples, 1) == 2);
+            assert(size(events(1).times, 1) == 2);
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(1, 1) - 1482333540553) < nirs_dt);
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(2, 1) - 1482333570823) < nirs_dt);
             utest_reset_bst();
@@ -441,7 +441,7 @@ classdef CSVImportTest < matlab.unittest.TestCase
                 'confirm_importation', 0);
             assert(~isempty(sFiles_processed));
             events = get_events(sFiles_processed);
-            assert(size(events(1).samples, 1) == 2);
+            assert(size(events(1).times, 1) == 2);
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(1, 1) - 1482333.540553) < nirs_dt);
             assert(abs(events(strcmp({events.label}, 'DMNirs')).times(2, 1) - 1482333.570823) < nirs_dt);
             utest_reset_bst();

--- a/test/CSVImportTest.m
+++ b/test/CSVImportTest.m
@@ -22,6 +22,54 @@ classdef CSVImportTest < matlab.unittest.TestCase
     
     methods(Test)
         
+        function test_csv_import_event_merge(testCase)
+            paradigm_fn = utest_request_data({'lesca_data','lesca_task_data_block.xls'});
+            paradigm_file_sel = {paradigm_fn, 'CSV'};
+            nirs_fn = utest_request_data({'dummy.nirs'});
+            nirs = load(nirs_fn, '-mat');
+            nirs_dt = diff(nirs.t(1:2));
+            
+            sFiles_dummy = utest_import_nirs_in_bst(nirs_fn);
+
+            event_orig = db_template('event');
+            event_orig.label = 'DMNirs';
+            event_orig.times = [10 ; 15];
+            event_orig.epochs     = ones(1, size(event_orig.times, 2));
+            event_orig.channels   = cell(1, size(event_orig.times, 2));
+            event_orig.notes      = cell(1, size(event_orig.times, 2));
+            process_nst_import_csv_events('import_events', [], sFiles_dummy, event_orig);
+            
+            trial_span_types = process_nst_import_csv_events('get_trial_spans_opt');
+            time_units = process_nst_import_csv_events('get_time_units_opt');
+            time_origin_types = process_nst_import_csv_events('get_time_origin_opt');
+            
+            sFiles_processed = bst_process('CallProcess', ...
+                'process_nst_import_csv_events', ...
+                sFiles_dummy, [], ...
+                'evtfile', paradigm_file_sel, ...
+                'delimiter', '\t', ...
+                'trial_label_column', 'blockType', ...
+                'trial_start_column', 'blockClockBegin', ...
+                'span_type', trial_span_types.START_END, ...
+                'trial_end_column', 'blockClockEnd', ...
+                'time_unit', time_units.MILLISECOND, ...
+                'time_origin_type', time_origin_types.OFFSET, ...
+                'time_origin_offset_sec', {0.0, '', 0}, ...
+                'entry_filters', 'dbCurrentSessionId=22555,blockType=DMNirs', ...
+                'max_events', 1000, ...
+                'confirm_importation', 0);
+            assert(~isempty(sFiles_processed));
+            events = get_events(sFiles_processed);
+            assert(length(events) == 1);
+            assert(size(events(1).times, 1) == 2);
+            
+            i_evt = strcmp({events.label}, 'DMNirs');
+            assert(events(i_evt).times(1, 1) == event_orig.times(1, 1));
+            assert(events(i_evt).times(2, 1) == event_orig.times(2, 1));
+            assert(abs(events(i_evt).times(1, 2) - 1482333540.553) <= nirs_dt);
+            assert(abs(events(i_evt).times(2, 2) - 1482333570.823) <= nirs_dt);
+        end
+        
         function test_csv_import_filters(testCase)
             global GlobalData;
             

--- a/test/SurfTplPipelineImportTest.m
+++ b/test/SurfTplPipelineImportTest.m
@@ -23,10 +23,11 @@ classdef SurfTplPipelineImportTest < matlab.unittest.TestCase
     methods(Test)
         
         function test_import_subjects(testCase)
-            nirs_fns = simulate_nirs();
-            options = nst_ppl_surface_template_V1('setup');
-            options.moco.export_dir = fullfile(testCase.tmp_dir, 'moco');
-            sFilesRaw = nst_ppl_surface_template_V1('import', {'data1.nirs', 'data2.nirs'}, {'subj1', 'subj2'});
+            % TODO
+%             nirs_fns = simulate_nirs();
+%             options = nst_ppl_surface_template_V1('setup');
+%             options.moco.export_dir = fullfile(testCase.tmp_dir, 'moco');
+%             sFilesRaw = nst_ppl_surface_template_V1('import', {'data1.nirs', 'data2.nirs'}, {'subj1', 'subj2'});
 
 
         end


### PR DESCRIPTION
As brainstorm decided to remove the sample filed from the event structure, we have to adapt our code to use time instead of sample. 

This is the list of process that still need changes :
- nst_make_event_toeplitz_mtx
- process_nst_import_evt_events
- process_nst_motion_correction

If you think of other process, don't hesitate to tell me.  

edit  ; my last commit for csv event isnt good, i'll fix it monday 