### PR TITLE
Replaced double quotes with single quotes

### DIFF
--- a/bst_plugin/preprocessing/process_nst_remove_ssc.m
+++ b/bst_plugin/preprocessing/process_nst_remove_ssc.m
@@ -108,7 +108,7 @@ for itype = 1 :length(types)
             model=nst_glm_add_regressors(model,'channel',sInput,'name',SS_name',types(itype));
         end    
     end 
-    model = nst_glm_add_regressors(model, "constant");
+    model = nst_glm_add_regressors(model, 'constant');
     
     nirs_ichans = strcmp( {ChannelMat.Channel.Type},'NIRS') & strcmp( {ChannelMat.Channel.Group},types{itype});
     Y= sDataIn.F(nirs_ichans,:)';


### PR DESCRIPTION
The newer syntax " to define strings make the parser of older Matlab versions crash.