### PR TITLE
Refactor extract sensitivity map to only include good channels

### DIFF
--- a/bst_plugin/forward/nst_headmodel_get_FOV.m
+++ b/bst_plugin/forward/nst_headmodel_get_FOV.m
@@ -1,4 +1,4 @@
-function valid_nodes = nst_headmodel_get_FOV(ChannelMat, cortex, thresh_dis2cortex, ChannelFlag)
+function [valid_nodes,dis2cortex] = nst_headmodel_get_FOV(ChannelMat, cortex, thresh_dis2cortex, ChannelFlag)
     %% define the reconstruction FOV
     
     if nargin < 4
@@ -18,6 +18,7 @@ function valid_nodes = nst_headmodel_get_FOV(ChannelMat, cortex, thresh_dis2cort
     Vertices_sm = cortex.Vertices;
     Vertices_sm(iVertices,:) = tess_smooth(cortex.Vertices(iVertices,:), 1, SurfSmoothIterations, cortex.VertConn(iVertices,iVertices), 1);
     dis2cortex = pdist2(Vertices_sm,optodes_pos);
+    dis2cortex = min(dis2cortex,[],2);
 
-    valid_nodes = find(min(dis2cortex,[],2)<thresh_dis2cortex);
+    valid_nodes = find(dis2cortex < thresh_dis2cortex);
 end

--- a/bst_plugin/forward/process_nst_extract_sensitivity_from_head_model.m
+++ b/bst_plugin/forward/process_nst_extract_sensitivity_from_head_model.m
@@ -132,7 +132,9 @@ end
 if sProcess.options.normalize.Value
     for iwl=1:nb_Wavelengths
         sensitivity_surf_sum(:,iwl) = log10(sensitivity_surf_sum(:,iwl) ./ max(sensitivity_surf_sum(:,iwl)));
-        sensitivity_surf_sum(sensitivity_surf_sum(:,iwl) < -2,iwl) = 0;
+        mask = zeros(size(sensitivity_surf_sum));
+        mask(:,iwl) = sensitivity_surf_sum(:,iwl) < -2;
+        sensitivity_surf_sum(mask == 1) = 0;
 
         k = zeros(1,  size(sensitivity_surf,3));
 


### PR DESCRIPTION
Modify the code that extracts the sensitivity map to only return the sensitivity associated with the good channels. 

