### PR TITLE
Merge nirs and EEG/MEG cMEM pipeline

### DIFF
--- a/bst_plugin/inverse/process_nst_cmem.m
+++ b/bst_plugin/inverse/process_nst_cmem.m
@@ -212,8 +212,9 @@ function [dOD_sources,Hb_sources, diagnosis] = Compute(OPTIONS,ChannelMat, sData
     
         %% launch MEM (cMEM only in current version)
         bst_progress('text', ['Running cMEM for wavelength #' num2str(iwl) '...']);
-        [Results, O_updated] = be_main_call_NIRS(HM, OPTIONS);
-        
+        %[Results, O_updated] = be_main_call_NIRS(HM, OPTIONS);
+         [Results, O_updated] = be_main_call(HM, OPTIONS);
+
         %cMEM results
         grid_amp = zeros(nb_nodes, nb_samples); 
         grid_amp(valid_nodes,:) = Results.ImageGridAmp;
@@ -263,8 +264,8 @@ function OPTIONS = getOptions(sProcess,HeadModel, DataFile)
     OPTIONS.DataTypes = {'NIRS'};
     OPTIONS.NoiseCov = [];
     OPTIONS.MEMpaneloptions.solver.NoiseCov_recompute   = 1;
-    OPTIONS.MEMpaneloptions.model.depth_weigth_MNE      = sProcess.options.depth_weightingMNE.Value{1};
-    OPTIONS.MEMpaneloptions.model.depth_weigth_MEM      = sProcess.options.depth_weightingMEM.Value{1};
+    %OPTIONS.MEMpaneloptions.model.depth_weigth_MNE      = sProcess.options.depth_weightingMNE.Value{1};
+    %OPTIONS.MEMpaneloptions.model.depth_weigth_MEM      = sProcess.options.depth_weightingMEM.Value{1};
     OPTIONS.MEMpaneloptions.model.NoiseCov_recompute    = sProcess.options.NoiseCov_recompute.Value;
 
     OPTIONS.thresh_dis2cortex = sProcess.options.thresh_dis2cortex.Value{1}.*0.01;

--- a/bst_plugin/inverse/process_nst_cmem.m
+++ b/bst_plugin/inverse/process_nst_cmem.m
@@ -51,14 +51,6 @@ function sProcess = GetDescription() %#ok<DEFNU>
     sProcess.options.thresh_dis2cortex.Type    = 'value';
     sProcess.options.thresh_dis2cortex.Value   = {3, 'cm',2};
     
-    sProcess.options.depth_weightingMNE.Comment = 'Depth weighting factor for <B>MNE</B>';
-    sProcess.options.depth_weightingMNE.Type    = 'value';
-    sProcess.options.depth_weightingMNE.Value   = {0.5, '', 1};
-    
-    sProcess.options.depth_weightingMEM.Comment = 'Depth weighting factor for <B>MEM</B>';
-    sProcess.options.depth_weightingMEM.Type    = 'value';
-    sProcess.options.depth_weightingMEM.Value   = {0.3, '', 1};
-
     sProcess.options.NoiseCov_recompute.Comment = 'Compute noise convariance for MNE';
     sProcess.options.NoiseCov_recompute.Type    = 'checkbox';
     sProcess.options.NoiseCov_recompute.Value   = 1;

--- a/bst_plugin/inverse/process_nst_cmem.m
+++ b/bst_plugin/inverse/process_nst_cmem.m
@@ -93,11 +93,17 @@ end
 
 % Get plugin information
 PluginDescription  = bst_plugin('GetInstalled', 'brainentropy'); 
-if isempty(PluginDescription.GetVersionFcn) || bst_plugin('CompareVersions', PluginDescription.GetVersionFcn(), '2.7.4')  < 1
-    bst_error('Please update the BrainEntropy toolbox to the verson 2.7.4 or higher');
-    return;
+if isempty(PluginDescription.GetVersionFcn) || bst_plugin('CompareVersions', PluginDescription.GetVersionFcn(), '2.7.4') < 0
+   bst_error('Please update the BrainEntropy toolbox to the verson 2.7.4 or higher');
+   return;
 end
 
+%% backward compatibility
+if isfield(sProcess.options, 'depth_weightingMNE') && isfield(sProcess.options, 'depth_weightingMEM')
+    bst_report('Warning', sProcess, sInputs, 'Options for depth-weighting was moved to MEM panel. Please update your script')
+    sProcess.options.mem.Value.MEMpaneloptions.model.depth_weigth_MNE      = sProcess.options.depth_weightingMNE.Value{1};
+    sProcess.options.mem.Value.MEMpaneloptions.model.depth_weigth_MEM      = sProcess.options.depth_weightingMEM.Value{1};
+end
 %% Load head model
 sStudy = bst_get('Study', sInputs.iStudy);
 if isempty(sStudy.iHeadModel)
@@ -212,7 +218,6 @@ function [dOD_sources,Hb_sources, diagnosis] = Compute(OPTIONS,ChannelMat, sData
     
         %% launch MEM (cMEM only in current version)
         bst_progress('text', ['Running cMEM for wavelength #' num2str(iwl) '...']);
-        %[Results, O_updated] = be_main_call_NIRS(HM, OPTIONS);
          [Results, O_updated] = be_main_call(HM, OPTIONS);
 
         %cMEM results
@@ -264,8 +269,6 @@ function OPTIONS = getOptions(sProcess,HeadModel, DataFile)
     OPTIONS.DataTypes = {'NIRS'};
     OPTIONS.NoiseCov = [];
     OPTIONS.MEMpaneloptions.solver.NoiseCov_recompute   = 1;
-    %OPTIONS.MEMpaneloptions.model.depth_weigth_MNE      = sProcess.options.depth_weightingMNE.Value{1};
-    %OPTIONS.MEMpaneloptions.model.depth_weigth_MEM      = sProcess.options.depth_weightingMEM.Value{1};
     OPTIONS.MEMpaneloptions.model.NoiseCov_recompute    = sProcess.options.NoiseCov_recompute.Value;
 
     OPTIONS.thresh_dis2cortex = sProcess.options.thresh_dis2cortex.Value{1}.*0.01;

--- a/bst_plugin/inverse/process_nst_cmem.m
+++ b/bst_plugin/inverse/process_nst_cmem.m
@@ -95,6 +95,14 @@ end
 % Install/load brainentropy plugin
 [isInstalled, errMessage] = bst_plugin('Install', 'brainentropy', 1);
 if ~isInstalled
+    bst_error('The Brainentropy toolbox is required to use MEM');
+    return;
+end
+
+% Get plugin information
+PluginDescription  = bst_plugin('GetInstalled', 'brainentropy'); 
+if isempty(PluginDescription.GetVersionFcn) || bst_plugin('CompareVersions', PluginDescription.GetVersionFcn(), '2.7.4')  < 1
+    bst_error('Please update the BrainEntropy toolbox to the verson 2.7.4 or higher');
     return;
 end
 


### PR DESCRIPTION
Linked to the update of the Brain Entropy toolbox (https://github.com/multifunkim/best-brainstorm/pull/4)

@rcassani Is there a way to ensure that both NIRSTORM and BrainEntropy are updated at the same time as this PR will only work if the PR (https://github.com/multifunkim/best-brainstorm/pull/4) is applied ?
