### PR TITLE
use v6 option to save voronoi

### DIFF
--- a/bst_plugin/forward/process_nst_compute_voronoi.m
+++ b/bst_plugin/forward/process_nst_compute_voronoi.m
@@ -253,7 +253,7 @@ if nargin > 5
 end
 
 % Save new MRI in Brainstorm format
-out_mri_bst(sMri, vol_fn);
+out_mri_bst(sMri, vol_fn,'v6');
 
 % If the MRI already exist, no need to go further.
 if ~is_new 


### PR DESCRIPTION

With v7 option; 

<img width="1422" alt="image" src="https://github.com/Nirstorm/nirstorm/assets/24530402/ee6fd7e7-dd4d-4e30-a82d-fdf19e472ebd">

With v6 option: 

<img width="1422" alt="image" src="https://github.com/Nirstorm/nirstorm/assets/24530402/8d2c6c83-c9c4-4e03-9fd1-fe08555ecce8">
