### PR TITLE
Update URL for NIRS files to Brainstorm server

### DIFF
--- a/bst_plugin/io/nst_get_repository_url.m
+++ b/bst_plugin/io/nst_get_repository_url.m
@@ -1,3 +1,3 @@
 function repo_url = nst_get_repository_url()
-repo_url = 'http://thomasvincent.xyz/nst_data';
+repo_url = 'https://neuroimage.usc.edu/resources/nst_data';
 end


### PR DESCRIPTION
Change the URL for fluence NIRS files to Brainstorm server 

From: http://thomasvincent.xyz/nst_data
To: https://neuroimage.usc.edu/resources/nst_data

NIRS files hosted in Brainstorm server: 

```
nst_data/
├─ fluence/
│  ├─ MRI__Colin27_4NIRS/
│  │  ├─ fluence_685nm_v000001.mat
│  │  ├─ fluence_685nm_v000002.mat
⋮   ⋮  ⋮      ⋮      ⋮       ⋮     ⋮     
│  │  ├─ fluence_685nm_v010242.mat
└  └  └─ fluence_file_sizes.csv
```

