### PR TITLE
fix MEM file saving on linux

### DIFF
--- a/bst_plugin/inverse/process_nst_cmem.m
+++ b/bst_plugin/inverse/process_nst_cmem.m
@@ -432,7 +432,7 @@ function [sStudy, ResultFile] = add_surf_data(data, time, head_model, name, ...
     % History
     ResultsMat = bst_history('add', ResultsMat, 'compute', history_comment);
     % Save new file structure
-    bst_save(ResultFile, ResultsMat, 'v6');
+    bst_save(ResultFile, ResultsMat);
     % ===== REGISTER NEW FILE =====
     % Create new results structure
     newResult = db_template('results');
@@ -448,8 +448,10 @@ function [sStudy, ResultFile] = add_surf_data(data, time, head_model, name, ...
     bst_set('Study', sInputs.iStudy, sStudy);
 end
 
-function sfn = protect_fn_str(s)
-sfn = strrep(s, ' ', '_');
+function sfn = protect_fn_str(sfn)
+    sfn = strrep(sfn, ' ', '_');
+    sfn = strrep(sfn, '|','');
+    sfn = strrep(sfn, ':', '_');
 end
 
 function VoisinsOA = adj2Voisins(adj)


### PR DESCRIPTION
Filename cannot contains '|'


@rcassani, FYI. It took me some time to figure out why Brainstorm was telling me the disk was full : 

"Error using bst_save (line 103)
Could not save file:
/bst_db/TutorialNIRSTORM/data/sub-01/sub-01_task-tapping_run-01_dOD__motioncorr_band_scr/results_NIRS_cMEM_|_timewindow:_-10_to_35s_|_smooth=0.6_|_WL685nm_250124_1123.mat
Disk full, disconnected or read-only."

when the actual error when executing save was: 

"Error using save
Unable to write file
/bst_db/TutorialNIRSTORM/data/sub-01/sub-01_task-tapping_run-01_dOD__motioncorr_band_scr/results_NIRS_cMEM_|_timewindow:_-10_to_35s_|_smooth=0.6_|_WL685nm_250124_1123.mat:
Invalid argument."

