### PR TITLE
[bugfix] Improve compatibility 

### DIFF
--- a/bst_plugin/math/nst_mne_lcurve.m
+++ b/bst_plugin/math/nst_mne_lcurve.m
@@ -97,11 +97,11 @@ function J = nst_mne_lcurve(HM,OPTIONS)
 
         % Estimate the corresponding norm
         R = qr(residual_kernal*U);
-        R = triu(R);
+        R = triu(R); % BUGFIX for old version of matlab (<2022a).
         Fit(iAlpha)     = norm(R*S);
 
         R = qr(wKernel*U);
-        R = triu(R);
+        R = triu(R); % BUGFIX for old version of matlab (<2022a).
         Prior(iAlpha)   = norm(R*S);
 
     

--- a/bst_plugin/math/nst_mne_lcurve.m
+++ b/bst_plugin/math/nst_mne_lcurve.m
@@ -97,9 +97,11 @@ function J = nst_mne_lcurve(HM,OPTIONS)
 
         % Estimate the corresponding norm
         R = qr(residual_kernal*U);
+        R = triu(R);
         Fit(iAlpha)     = norm(R*S);
 
         R = qr(wKernel*U);
+        R = triu(R);
         Prior(iAlpha)   = norm(R*S);
 
     

--- a/bst_plugin/math/nst_tddr_correction.m
+++ b/bst_plugin/math/nst_tddr_correction.m
@@ -35,8 +35,13 @@ Fc = filter_cutoff * 2/sample_rate;
 signal_mean = mean(signal);
 signal = signal - signal_mean;
 if Fc<1
-    [fb,fa] = butter(filter_order,Fc);
-    signal_low = filtfilt(fb,fa,signal);
+    if bst_get('UseSigProcToolbox') 
+        [fb,fa] = butter(filter_order,Fc);
+        signal_low = filtfilt(fb,fa,signal);
+    else
+        [fb,fa] = oc_butter(filter_order,Fc);
+        signal_low = oc_filtfilt(fb,fa,signal);
+    end
 else
     signal_low = signal;
 end


### PR DESCRIPTION
- Fix a bug in TDDR if signal processing toolbox is not available 
- Fix a bug in MNE for matlab older than 2022a. The QR decomposition was not returning a triangular matrix in older version of matlab. 