### PR TITLE
[bugfix] Better check for voxel size of segmentation

### DIFF
--- a/bst_plugin/forward/process_nst_cpt_fluences.m
+++ b/bst_plugin/forward/process_nst_cpt_fluences.m
@@ -217,7 +217,7 @@ if ~any(iseg)
 end
 
 sSegmentation   = in_mri_bst(sSubject.Anatomy(iseg).FileName);
-if ~isequal(sMri.Voxsize,sSegmentation.Voxsize)
+if ~all(round(sMri.Voxsize(1:3) .* 1000) == round(sSegmentation.Voxsize(1:3) .* 1000))
     bst_report('Error', sProcess, [], 'MRI and Segmentation have different voxel size');
     return
 end


### PR DESCRIPTION
Voxel size should be checked up to 1/1000 of mm

Issue reported in https://neuroimage.usc.edu/forums/t/error-in-computing-fluences/52958/4