### PR TITLE
[bugfix] headmodel -- better detected old head model

### DIFF
--- a/bst_plugin/VERSION
+++ b/bst_plugin/VERSION
@@ -1,1 +1,1 @@
-stable_v0.9.4
+stable_v0.9.5

--- a/bst_plugin/forward/process_nst_extract_sensitivity_from_head_model.m
+++ b/bst_plugin/forward/process_nst_extract_sensitivity_from_head_model.m
@@ -116,7 +116,8 @@ function OutputFiles = Run(sProcess, sInputs)
     end
     
     head_model = in_bst_headmodel(sStudy.HeadModel(sStudy.iHeadModel).FileName, 1);
-    if ~isfield(head_model, 'NIRSMethod') && ndims(head_model.Gain) == 3
+    if ~(isfield(nirs_head_model, 'NIRSMethod') && ~isempty(nirs_head_model.NIRSMethod))
+        ChannelMat = in_bst_channel(sInputs(1).ChannelFile);
         head_model = process_nst_import_head_model('convert_head_model', ChannelMat, head_model, 0);
     end
     

--- a/bst_plugin/inverse/process_nst_cmem.m
+++ b/bst_plugin/inverse/process_nst_cmem.m
@@ -151,7 +151,7 @@ function sResults = Compute(OPTIONS, ChannelMat, sDataIn )
 
 
     nirs_head_model = in_bst_headmodel(OPTIONS.HeadModelFile, 1);
-    if ~isfield(nirs_head_model, 'NIRSMethod') && ndims(nirs_head_model.Gain) == 3
+    if ~(isfield(nirs_head_model, 'NIRSMethod') && ~isempty(nirs_head_model.NIRSMethod))
         nirs_head_model = process_nst_import_head_model('convert_head_model', ChannelMat, nirs_head_model, 0);
     end
 

--- a/bst_plugin/inverse/process_nst_wmne.m
+++ b/bst_plugin/inverse/process_nst_wmne.m
@@ -171,7 +171,7 @@ end
 function sResults = Compute(OPTIONS, ChannelMat, sDataIn )
 
     nirs_head_model = in_bst_headmodel(OPTIONS.HeadModelFile, 1);
-    if ~isfield(nirs_head_model, 'NIRSMethod') && ndims(nirs_head_model.Gain) == 3
+    if ~(isfield(nirs_head_model, 'NIRSMethod') && ~isempty(nirs_head_model.NIRSMethod))
         nirs_head_model = process_nst_import_head_model('convert_head_model', ChannelMat, nirs_head_model, 0);
     end
 


### PR DESCRIPTION
Since https://github.com/brainstorm-tools/brainstorm3/pull/815/commits/365aceecd79d872a67232dbd7523588a7b55a362 , NIRSmethoid can exist while being empty