### PR TITLE
[headmodel] save parameters in the history field

### DIFF
--- a/bst_plugin/forward/process_nst_import_head_model.m
+++ b/bst_plugin/forward/process_nst_import_head_model.m
@@ -137,11 +137,9 @@ function OutputFiles = Run(sProcess, sInput)
     HeadModelMat.SurfaceFile    = OPTIONS.CortexFile;
     HeadModelMat.GridOrient     = sCortex.VertNormals;
     HeadModelMat.Comment        = 'NIRS head model';
-    HeadModelMat.Param          = struct('FluenceFolder',    OPTIONS.FluenceFolder , ...
-                                         'smoothing_method', OPTIONS.smoothing_method, ...
-                                         'smoothing_fwhm',   OPTIONS.smoothing_fwhm);
-    
-    HeadModelMat                = bst_history('add', HeadModelMat, 'compute', 'Compute NIRS head model from MCX fluence results');
+
+    strHistory =  [sprintf('Fluence: %s, SmoothMethod: %s, SmoothFWHM: %1.3f', OPTIONS.FluenceFolder, OPTIONS.smoothing_method, OPTIONS.smoothing_fwhm)];
+    HeadModelMat = bst_history('add', HeadModelMat, 'compute', ['Compute head model: ##', 'Import (NIRS)' , '##' strHistory]);
 
 
     % Save Head Model


### PR DESCRIPTION
Following change made in https://github.com/brainstorm-tools/brainstorm3/commit/9547a16fe77f775e8686f2df824590a07569a132