### PR TITLE
Add process to cluster channels based on their proximity to cortical ROI

### DIFF
--- a/bst_plugin/preprocessing/process_nst_channel_cluter_auto.m
+++ b/bst_plugin/preprocessing/process_nst_channel_cluter_auto.m
@@ -1,0 +1,213 @@
+function varargout = process_nst_channel_cluter_auto( varargin )
+% process_channel_cluter_auto: Automatically create channel cluster based
+% on the distance to anatomical atlas. 
+
+% @=============================================================================
+% This function is part of the Brainstorm software:
+% https://neuroimage.usc.edu/brainstorm
+% 
+% Copyright (c) University of Southern California & McGill University
+% This software is distributed under the terms of the GNU General Public License
+% as published by the Free Software Foundation. Further details on the GPLv3
+% license can be found at http://www.gnu.org/copyleft/gpl.html.
+% 
+% FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
+% UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
+% WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+% MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
+% LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
+%
+% For more information type "brainstorm license" at command prompt.
+% =============================================================================@
+%
+% Authors: Edouard Delaire, 2026
+
+eval(macro_method);
+end
+
+
+%% ===== GET DESCRIPTION =====
+function sProcess = GetDescription()
+    % Description the process
+    sProcess.Comment     = 'Clusters channels (auto)';
+    sProcess.Category    = 'Custom';
+    sProcess.SubGroup    = {'NIRS', 'Pre-process'};
+    sProcess.Index       = 1202;
+    sProcess.Description = 'https://neuroimage.usc.edu/brainstorm/Tutorials/ChannelClusters';
+    % Definition of the input accepted by this process
+    sProcess.InputTypes  = {'data', 'raw'};
+    sProcess.OutputTypes = {'data', 'raw'};
+    sProcess.nInputs     = 1;
+    sProcess.nMinFiles   = 1;
+
+    % === TEST: title
+    sProcess.options.test_title.Comment    = '<BR><B><U>Clustering method</U></B>:';
+    sProcess.options.test_title.Type       = 'label';
+    % === Clustering method
+    sProcess.options.clustering_type.Comment = {'<B>Distance</B> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <FONT COLOR="#777777"><I> For each channel, assign the clostest ROI to each channel </I></FONT>', ...
+                                          '<B>Sensitivity</B> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <FONT COLOR="#777777"><I>For each channel, assign the ROI with the most sensitivity</I></FONT>'; ...
+                                          'distance', 'sensitivity'};
+    sProcess.options.clustering_type.Type    = 'radio_label';
+    sProcess.options.clustering_type.Value   = 'distance';
+
+
+    % === SCOUTS SELECTION
+    sProcess.options.scouts.Comment    = 'Use scouts';
+    sProcess.options.scouts.Type       = 'scout';
+    sProcess.options.scouts.Value      = {};
+
+end
+
+
+%% ===== FORMAT COMMENT =====
+function Comment = FormatComment(sProcess)
+    Comment = sProcess.Comment;
+end
+
+
+%% ===== RUN =====
+function OutputFiles = Run(sProcess, sInputs)
+    
+    % Load channel information
+    ChannelMat  = in_bst_channel(sInputs.ChannelFile);
+    iChannels   = channel_find(ChannelMat.Channel, 'NIRS');
+    if isempty(iChannels)
+        bst_error('Unable to find NIRS channel')
+        return;
+    end
+
+    sChannel        = ChannelMat.Channel(iChannels);
+    channels_groups = unique({sChannel.Group});
+    nGroup          = max(length(channels_groups), 1);
+    
+    % Load Cortex and Scout information
+    sSubject = bst_get('Subject', sInputs.SubjectName);
+    sCortex  = in_tess_bst(sSubject.Surface(sSubject.iCortex).FileName);
+    
+    iAtlas = find(strcmp({sCortex.Atlas.Name}, sProcess.options.scouts.Value{1}));
+    if isempty(iAtlas)
+        bst_error(sprintf('Unable to find atlas %s',  sProcess.options.scouts.Value{1}))
+        return;
+    end
+    iScouts = cellfun(@(x) find(strcmp({sCortex.Atlas(iAtlas).Scouts.Label}, x)), sProcess.options.scouts.Value{2});
+    sScout = sCortex.Atlas(iAtlas).Scouts(iScouts);
+    nScouts = length(sScout);
+
+    % Cluster channels
+    switch(sProcess.options.clustering_type.Value)
+        case 'distance'
+            idx_roi  = ClusterChannelUsingDistance(sCortex, sChannel, sScout);
+        case 'sensitivity'
+            sStudy = bst_get('Study', sInputs.iStudy);
+            sHead = in_bst_headmodel(sStudy.HeadModel(sStudy.iHeadModel).FileName, 1);
+            idx_roi  = ClusterChannelUsingSensitivity(sHead, sChannel, sScout);
+        otherwise
+            error('Unknown method %s', sProcess.options.clustering_type.Value)
+    end
+
+    % Create clusters
+    sClusters = repmat(db_template('cluster'), 1, nGroup * nScouts);
+    k = 1;
+    for iScout = 1:nScouts
+        for iGroup = 1:nGroup
+            if ~isempty(channels_groups(iGroup))
+                sClusters(k).Label = sprintf('%s - %s', sScout(iScout).Label, channels_groups{iGroup});
+            else
+                sClusters(k).Label = sprintf('%s', sScout(iScout).Label);
+            end
+
+            sClusters(k).Color = sScout(iScout).Color;
+            sClusters(k).Function = sScout(iScout).Function;
+            sClusters(k).Sensors = {sChannel(idx_roi == iScout).Name};
+            k = k +1;
+        end
+    end
+
+    % Add or replace clusters in the channel file
+    for i = 1:length(sClusters)
+
+        if isempty(sClusters(i).Sensors)
+            % do not create empty cluster
+            continue
+        end
+
+        % If cluster already exists, update it, otherwise create a new entry
+        if ~isfield(ChannelMat, 'Clusters') || isempty(ChannelMat.Clusters)
+            ChannelMat.Clusters = repmat(db_template('cluster'), 0, 1);
+            iCluster = 1;
+        else
+            iCluster = find(strcmp(sClusters(i).Label, {ChannelMat.Clusters.Label}));
+            if isempty(iCluster)
+                iCluster = length(ChannelMat.Clusters) + 1;
+            end
+        end
+        % Copy all the fields
+        ChannelMat.Clusters(iCluster).Sensors  = sClusters(i).Sensors;
+        ChannelMat.Clusters(iCluster).Label    = sClusters(i).Label;
+        ChannelMat.Clusters(iCluster).Function = sClusters(i).Function;
+        % Add color if not defined yet
+        if ~isempty(sClusters(i).Color)
+            ChannelMat.Clusters(iCluster).Color = sClusters(i).Color;
+        else
+            ColorTable = panel_scout('GetScoutsColorTable');
+            iColor = mod(iCluster-1, length(ColorTable)) + 1;
+            ChannelMat.Clusters(i).Color = ColorTable(iColor,:);
+        end
+    end
+
+    % Save modified file
+    bst_save(file_fullpath(sInputs.ChannelFile), ChannelMat, 'v7');
+    OutputFiles = {sInputs.FileName};
+end
+
+
+
+function [idx_roi, dist] = ClusterChannelUsingDistance(sCortex, sChannels, sScouts)
+    % For each channel, return the index of the closest ROI (using euclidean distance)
+    % sScout(idx_roi) and the distance of the channel to that scout. 
+    
+    % Initialize output
+    dist = zeros(length(sChannels), length(sScouts));
+
+    % Compute distances
+    for iChannel = 1:length(sChannels)
+
+        if size(sChannels(iChannel).Loc, 2) == 2
+            channel_loc =  mean(sChannels(iChannel).Loc, 2);
+        else
+            channel_loc =  sChannels(iChannel).Loc;
+        end
+
+        for iScout = 1:length(sScouts)
+
+            y =  sCortex.Vertices(sScouts(iScout).Vertices, :);
+            x =  repmat(channel_loc', size(y, 1), 1);
+
+            distance_channel_ROI = sqrt(sum( (x  - y).^2, 2));
+            dist(iChannel, iScout) = min(distance_channel_ROI);
+        end
+    end
+
+    [dist, idx_roi] = min(dist, [], 2);
+end
+
+
+function [idx_roi, dist] = ClusterChannelUsingSensitivity(sHead, sChannels, sScouts)
+    % For each channel, return the index of the closest ROI (using sensitivity)
+    % sScout(idx_roi) and the distance of the channel to that scout. 
+    
+    % Initialize output
+    dist = zeros(length(sChannels), length(sScouts));
+
+    % Compute distances
+    for iChannel = 1:length(sChannels)
+
+        for iScout = 1:length(sScouts)
+            distance_channel_ROI    = abs(sHead.Gain(iChannel, sScouts(iScout).Vertices));
+            dist(iChannel, iScout)  = sum(distance_channel_ROI);
+        end
+    end
+
+    [dist, idx_roi] = max(dist, [], 2);
+end
+

--- a/bst_plugin/preprocessing/process_nst_channel_cluter_auto.m
+++ b/bst_plugin/preprocessing/process_nst_channel_cluter_auto.m
@@ -125,12 +125,7 @@ function OutputFiles = Run(sProcess, sInputs)
 
     % Add or replace clusters in the channel file
     for i = 1:length(sClusters)
-
-        if isempty(sClusters(i).Sensors)
-            % do not create empty cluster
-            continue
-        end
-
+        
         % If cluster already exists, update it, otherwise create a new entry
         if ~isfield(ChannelMat, 'Clusters') || isempty(ChannelMat.Clusters)
             ChannelMat.Clusters = repmat(db_template('cluster'), 0, 1);
@@ -141,6 +136,17 @@ function OutputFiles = Run(sProcess, sInputs)
                 iCluster = length(ChannelMat.Clusters) + 1;
             end
         end
+
+        if isempty(sClusters(i).Sensors) 
+            % do not create empty cluster
+            if iCluster <= length(ChannelMat.Clusters)
+                % Remove previous cluster
+                ChannelMat.Clusters(iCluster) = []; 
+            end
+
+            continue
+        end
+
         % Copy all the fields
         ChannelMat.Clusters(iCluster).Sensors  = sClusters(i).Sensors;
         ChannelMat.Clusters(iCluster).Label    = sClusters(i).Label;

--- a/bst_plugin/preprocessing/process_nst_channel_cluter_auto.m
+++ b/bst_plugin/preprocessing/process_nst_channel_cluter_auto.m
@@ -90,16 +90,28 @@ function OutputFiles = Run(sProcess, sInputs)
         return;
     end
     iScouts = cellfun(@(x) find(strcmp({sCortex.Atlas(iAtlas).Scouts.Label}, x)), sProcess.options.scouts.Value{2});
-    sScout = sCortex.Atlas(iAtlas).Scouts(iScouts);
+    if isempty(iScouts)
+        bst_error(sprintf('Unable to find scout %s.', sProcess.options.scouts.Value{2}))
+        return;
+    end
+    sScout  = sCortex.Atlas(iAtlas).Scouts(iScouts);
     nScouts = length(sScout);
+
+    % Load headmodel
+    if strcmp(sProcess.options.clustering_type.Value, 'sensitivity')
+        sStudy = bst_get('Study', sInputs.iStudy);
+        if isempty(sStudy.HeadModel)
+            bst_error('Unable to find NIRS headmodel')
+            return;
+        end
+        sHead = in_bst_headmodel(sStudy.HeadModel(sStudy.iHeadModel).FileName, 1);
+    end
 
     % Cluster channels
     switch(sProcess.options.clustering_type.Value)
         case 'distance'
             idx_roi  = ClusterChannelUsingDistance(sCortex, sChannel, sScout);
         case 'sensitivity'
-            sStudy = bst_get('Study', sInputs.iStudy);
-            sHead = in_bst_headmodel(sStudy.HeadModel(sStudy.iHeadModel).FileName, 1);
             idx_roi  = ClusterChannelUsingSensitivity(sHead, sChannel, sScout);
         otherwise
             error('Unknown method %s', sProcess.options.clustering_type.Value)
@@ -125,7 +137,7 @@ function OutputFiles = Run(sProcess, sInputs)
 
     % Add or replace clusters in the channel file
     for i = 1:length(sClusters)
-        
+
         % If cluster already exists, update it, otherwise create a new entry
         if ~isfield(ChannelMat, 'Clusters') || isempty(ChannelMat.Clusters)
             ChannelMat.Clusters = repmat(db_template('cluster'), 0, 1);

--- a/bst_plugin/preprocessing/process_nst_separations.m
+++ b/bst_plugin/preprocessing/process_nst_separations.m
@@ -31,7 +31,7 @@ function sProcess = GetDescription()
 sProcess.Comment     = 'Compute separations';
 sProcess.Category    = 'File';
 sProcess.SubGroup    = {'NIRS', 'Pre-process'};
-sProcess.Index       = 1202;
+sProcess.Index       = 1203;
 sProcess.isSeparator = 1;
 sProcess.Description = 'https://github.com/Nirstorm/nirstorm/wiki/Optode-separations';
 


### PR DESCRIPTION
This process allows for automatic clustering of channels based on their distance to the ROI on the cortex. 

The clustering can be performed either based on Euclidean distance or sensitivity. When using sensitivity, we attribute, for each channel, the ROI with the most sensitivity. 

**Note**: @rcassani  Is there an easy way to visualize channels from a specific cluster? Or to visualize how the channels are in different clusters on the scalp?
<img width="230" height="272" alt="image" src="https://github.com/user-attachments/assets/c8d826ec-5a45-446e-bb49-83c27afb3f27" />

is not very informative. There is 48 channels in c1 but which one ? where are they ? :) 

Process: 
<img width="420" height="456" alt="image" src="https://github.com/user-attachments/assets/f74e9f29-219e-48a4-9ca1-01f95cc9f71a" />


See https://github.com/brainstorm-tools/brainstorm3/pull/891